### PR TITLE
Rename Elixxir to XXNetwork

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,7 @@ const CLA = {
   POLKADEX: 0xa0,
   BIFROST: 0xa1,
   REEF: 0xa2,
-  ELIXXIR: 0xa3,
+  XXNETWORK: 0xa3,
 }
 
 // https://github.com/satoshilabs/slips/blob/master/slip-0044.md
@@ -38,7 +38,7 @@ const SLIP0044 = {
   KARURA: 0x800002ae,
   REEF: 0x80000333,
   ACALA: 0x80000313,
-  ELIXXIR: 0x800007a3,
+  XXNETWORK: 0x800007a3,
 }
 
 const SS58_ADDR_TYPE = {
@@ -59,7 +59,7 @@ const SS58_ADDR_TYPE = {
   KARURA: 8,
   REEF: 42,
   ACALA: 10,
-  ELIXXIR: 55,
+  XXNETWORK: 55,
 }
 
 module.exports = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -74,4 +74,4 @@ export const newBifrostApp: SubstrateAppCreator
 export const newKaruraApp: SubstrateAppCreator
 export const newReefApp: SubstrateAppCreator
 export const newAcalaApp: SubstrateAppCreator
-export const newElixxirApp: SubstrateAppCreator
+export const newXXNetworkApp: SubstrateAppCreator

--- a/src/index.js
+++ b/src/index.js
@@ -397,8 +397,8 @@ function newAcalaApp(transport) {
   return new SubstrateApp(transport, CLA.ACALA, SLIP0044.ACALA)
 }
 
-function newElixxirApp(transport) {
-  return new SubstrateApp(transport, CLA.ELIXXIR, SLIP0044.ELIXXIR)
+function newXXNetworkApp(transport) {
+  return new SubstrateApp(transport, CLA.XXNETWORK, SLIP0044.XXNETWORK)
 }
 
 function sha512(data) {
@@ -506,5 +506,5 @@ module.exports = {
   newKaruraApp,
   newReefApp,
   newAcalaApp,
-  newElixxirApp,
+  newXXNetworkApp,
 }


### PR DESCRIPTION
This renames the CLA, SLIP44 and SS58 definitions from `ELIXXIR` to `XXNETWORK`.

It also renames the `newElixxirApp` function to `newXXNetworkApp`.