### PR TITLE
Export supportedApps from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,4 @@
 
 export * from './legacy_apps'
 export { SubstrateApp } from './substrate_app'
-export { newSubstrateApp } from './supported_apps'
+export { newSubstrateApp, supportedApps } from './supported_apps'


### PR DESCRIPTION
Just integrated the new shiny version in https://github.com/polkadot-js/common/pull/1630 and it certainly would make things _slightly_ cleaner if there is access to `supportedApps` from the root import.

The is almost cosmetic since I only use it in tests to ensure key consistency, but since the old stuff is marked legacy now, it would help to just clean up, at least for my usage.

<!-- ClickUpRef: 2vxf972 -->
:link: [zboto Link](https://app.clickup.com/t/2vxf972)