### PR TITLE
Change bittensor to ss58 42

### DIFF
--- a/src/supported_apps.ts
+++ b/src/supported_apps.ts
@@ -250,7 +250,7 @@ export const supportedApps: SubstrateAppParams[] = [
     name: 'Bittensor',
     cla: 0xb4,
     slip0044: 0x800003ed,
-    ss58_addr_type: 13116,
+    ss58_addr_type: 42,
   },
   {
     name: 'Ternoa',


### PR DESCRIPTION
Bittensor has yet to move over to the new ss58 format, so we should put it back to `42` until then

<!-- ClickUpRef: 861mhm53q -->
:link: [zboto Link](https://app.clickup.com/t/861mhm53q)