### PR TITLE
fix: ensure error message is correct for chainId and svrUrl, and add bip32path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ display the address on the device. By default, it will retrieve the information 
   - **txMetadataChainId**: This is the id of the chain where you intend to sign transactions. This should match the chain id configured at the generic app API service.
   - **txMetadataSrvUrl**: This is the URL for the generic app API service, which generates the transaction metadata needed for signing transactions on the device. Zondax provides a live demo of this service. The url is:
     - https://api.zondax.ch/polkadot/transaction/metadata
+- Important Note: The expected bip32Path spec requires the following format - `m/44'/{slip44}'/{account}'/0'/{addressIndex}'`
 
 3. **Configure Address Retrieval**:
 

--- a/src/generic_app.ts
+++ b/src/generic_app.ts
@@ -79,14 +79,14 @@ export class PolkadotGenericApp extends BaseApp {
     if (!txMetadataChainIdVal) {
       throw new ResponseError(
         LedgerError.GenericError,
-        'txMetadataSrvUrl is not defined or is empty. The use of the method requires access to a metadata shortening service.'
+        'txMetadataChainId is not defined or is empty. The use of the method requires access to a metadata shortening service.'
       )
     }
 
     if (!txMetadataSrvUrlVal) {
       throw new ResponseError(
         LedgerError.GenericError,
-        'txMetadataChainId is not defined or is empty. These values are configured in the metadata shortening service. Check the corresponding configuration in the service.'
+        'txMetadataSrvUrl is not defined or is empty. These values are configured in the metadata shortening service. Check the corresponding configuration in the service.'
       )
     }
 


### PR DESCRIPTION
The following PR ensures the errors map to the correct checks for chainId and svrUrl.

I also noticed it hard to find specific docs about the `bip32Path` and the expected input so I placed the correct format in the migration docs to make it clear for new users.

Thanks again.

<!-- ClickUpRef: 869536eew -->
:link: [zboto Link](https://app.clickup.com/t/869536eew)