### PR TITLE
add integritee chain support

### DIFF
--- a/src/supported_apps.ts
+++ b/src/supported_apps.ts
@@ -314,4 +314,10 @@ export const supportedApps: SubstrateAppParams[] = [
     slip0044: 0x8000003c,
     ss58_addr_type: 42,
   },
+    {
+    name: 'Encointer',
+    cla: 0x62,
+    slip0044: 0x800001b2,
+    ss58_addr_type: 2,
+  },
 ]

--- a/src/supported_apps.ts
+++ b/src/supported_apps.ts
@@ -315,16 +315,9 @@ export const supportedApps: SubstrateAppParams[] = [
     ss58_addr_type: 42,
   },
   {
-    name: 'Encointer',
-    cla: 0x62,
-    slip0044: 0x800001b2,
-    ss58_addr_type: 2,
-  },
-  {
     name: 'Integritee',
-    cla: 0x63,
+    cla: 0x62,
     slip0044: 0x800007df,
     ss58_addr_type: 13,
   },
-
 ]

--- a/src/supported_apps.ts
+++ b/src/supported_apps.ts
@@ -314,10 +314,17 @@ export const supportedApps: SubstrateAppParams[] = [
     slip0044: 0x8000003c,
     ss58_addr_type: 42,
   },
-    {
+  {
     name: 'Encointer',
     cla: 0x62,
     slip0044: 0x800001b2,
     ss58_addr_type: 2,
   },
+  {
+    name: 'Integritee',
+    cla: 0x63,
+    slip0044: 0x800007df,
+    ss58_addr_type: 13,
+  },
+
 ]


### PR DESCRIPTION
The Integritee Network runtime is ready for ledger support. Adding it here
 
slip44 registered here: https://github.com/satoshilabs/slips/pull/1785

<!-- ClickUpRef: 8695mgdm1 -->
:link: [zboto Link](https://app.clickup.com/t/8695mgdm1)