### PR TITLE
Use generic app for bittensor

### DIFF
--- a/src/supported_apps.ts
+++ b/src/supported_apps.ts
@@ -250,7 +250,7 @@ export const supportedApps: SubstrateAppParams[] = [
   },
   {
     name: 'Bittensor',
-    cla: 0xb4,
+    cla: 0xf9,
     slip0044: 0x800003ed,
     ss58_addr_type: 42,
   },


### PR DESCRIPTION
This changes the CLA to `0xf9` so Bittensor will be indicated as supporting the Generic Polkadot app. 
We made the necessary runtime upgrade today.

<!-- ClickUpRef: 8695qautk -->
:link: [zboto Link](https://app.clickup.com/t/8695qautk)