### PR TITLE
Add support for Mythos

### DIFF
--- a/src/supported_apps.ts
+++ b/src/supported_apps.ts
@@ -320,4 +320,10 @@ export const supportedApps: SubstrateAppParams[] = [
     slip0044: 0x80000162,
     ss58_addr_type: 42,
   },
+  {
+    name: 'Mythos',
+    cla: 0xbf,
+    slip0044: 0x8000003c,
+    ss58_addr_type: 42,
+  },
 ]


### PR DESCRIPTION
This PR adds support for the [Mythos](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fpolkadot-mythos-rpc.polkadot.io#/explorer) chain.

The Mythos chain:
- Does not support smart contracts, but uses EVM-like addresses and Ethereum-like account derivation and that is why I have  set the BIP44 to Ethereum (0x8000003c).
- Since addresses are 20-byte long, the ss58 prefix is not required and defaults to 42.

<!-- ClickUpRef: 8697d73gj -->
:link: [zboto Link](https://app.clickup.com/t/8697d73gj)