### PR TITLE
ci: revert _publish-npm.yaml to @v7

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish-npm:
-    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v7
+    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@fix/publish-npm-corepack-upgrade
     permissions:
       contents: read
       id-token: write # Required for OIDC trusted publishing - must be in caller!

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish-npm:
-    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@fix/publish-npm-corepack-upgrade
+    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v7
     permissions:
       contents: read
       id-token: write # Required for OIDC trusted publishing - must be in caller!

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish-npm:
-    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v11
+    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v7
     permissions:
       contents: read
       id-token: write # Required for OIDC trusted publishing - must be in caller!


### PR DESCRIPTION
Reverts the publish workflow from `_publish-npm.yaml@v11` back to `@v7`.

### Why

`@v11` cannot publish to npm. Its npm upgrade step is a no-op — `corepack prepare npm@latest --activate` records the version in `COREPACK_HOME` but does not put that npm on PATH, so publishing runs on the runner's bundled npm. That npm predates OIDC trusted publishing, so it falls through to the placeholder `_authToken` that `setup-node` writes into `.npmrc`, and the registry reports the unauthorized publish as a misleading `E404`.

```
Current npm version: 10.9.8
Updated npm version: 10.9.8        ← upgrade silently did nothing
npm error 404 '<pkg>@<version>' is not in this registry.
```

It has already cost two releases:

| Release | Result | npm |
|---|---|---|
| ledger-filecoin-js v3.0.10 | `E404` | still 3.0.9 |
| ledger-substrate-js v2.3.6 | `E404` | still 2.3.5 |

`@v7` uses `npm install -g npm@latest`, which does take effect — confirmed the same day on a run reporting `Updated npm version: 12.0.1`.

### Scope

Only the reusable workflow ref changes. Nothing else is touched.

```diff
-    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v11
+    uses: zondax/_workflows/.github/workflows/_publish-npm.yaml@v7
```